### PR TITLE
Document issue with expanded databases reconnecting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file.
 
+## [3.2.1] - 2025-11-06
+
+- Documentation update
+
 ## [3.2.0] - 2025-11-06
 
 ### Added

--- a/docs/KNOWN_ISSUES.md
+++ b/docs/KNOWN_ISSUES.md
@@ -2,6 +2,12 @@
 
 ## Current Known Issues
 
+### Expanded Databases Reconnect on Close
+
+**Issue:** Not Collapsing connection tree items before disconnecting causes an immediate auto-reconnect when a tree was expanded — the disconnect command should collapses the connection node first to avoid triggering the expansion-driven connect path.
+
+**Workaround:** Collapse the tree manually before clicking Disconnect
+
 ### Pagination Performance with Large Offsets
 
 **Issue:** Pagination using `OFFSET` becomes slower with very large offset values (10,000+ rows).


### PR DESCRIPTION
Added a known issue regarding expanded databases auto-reconnecting when the connection tree is not collapsed before disconnecting, along with a workaround.